### PR TITLE
Return password from environment variable

### DIFF
--- a/src/fvtt_autopublish/__init__.py
+++ b/src/fvtt_autopublish/__init__.py
@@ -344,6 +344,8 @@ def read_password(method: str) -> Optional[str]:
     elif method == "environment":
         result = os.environ.get(PASSWORD_ENV_VARIABLE)
         if result is None:
-            raise ValueError("Unable to read password: Environment variable ")
+            raise ValueError("Unable to read password: Environment variable")
+        else:
+            return result
     else:
         raise ValueError(f"Invalid method: {method}")


### PR DESCRIPTION
Fixes the following error when using `--password-source=environment`:

```
Traceback (most recent call last):
  File "/usr/local/bin/fvtt-autopublish", line 5, in <module>
    main()
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/tmp/autopublish/src/fvtt_autopublish/__init__.py", line 258, in main
    if len(password) == 0:
TypeError: object of type 'NoneType' has no len()
```